### PR TITLE
Tacos ayer

### DIFF
--- a/bots/MsTaco/src/persistence.py
+++ b/bots/MsTaco/src/persistence.py
@@ -66,4 +66,4 @@ def save_log(log):
 
 
 def daily_taco_cunt():
-    return sum([i['n_tacos'] for i in logs_db.search((Query().date == get_today()))])
+    return sum([i['n_tacos'] for i in logs_db.search((Query().date == get_yesterday()))])

--- a/bots/MsTaco/src/time_utils.py
+++ b/bots/MsTaco/src/time_utils.py
@@ -1,9 +1,13 @@
 import time
+import datetime
 
 # time variables
 from src.config import RESET_HOUR
 
 today = str(time.gmtime().tm_year) + str(time.gmtime().tm_mon).zfill(2) + str(time.gmtime().tm_mday).zfill(2)
+ayer = datetime.date.today() - datetime.timedelta(days = 1)
+yesterday = ayer.strftime('%Y%m%d')
+
 time_left = 0
 
 
@@ -23,6 +27,9 @@ def update_time():
 
 def get_today():
     return today
+
+def get_yesterday():
+    return yesterday
 
 
 def get_time_left():


### PR DESCRIPTION
Filtrar los tacos con la fecha del día anterior para devolver la suma de tacos que se repartieron ayer en la comunidad