### PR TITLE
Actualizar las variables `yesterday` y `lastweek`

### DIFF
--- a/bots/MsTaco/src/time_utils.py
+++ b/bots/MsTaco/src/time_utils.py
@@ -4,7 +4,7 @@ import datetime
 # time variables
 from src.config import RESET_HOUR
 
-today     = str(time.gmtime().tm_year) + str(time.gmtime().tm_mon).zfill(2) + str(time.gmtime().tm_mday).zfill(2)
+today = str(time.gmtime().tm_year) + str(time.gmtime().tm_mon).zfill(2) + str(time.gmtime().tm_mday).zfill(2)
 yesterday = (datetime.date.today() - datetime.timedelta(days = 1)).strftime('%Y%m%d')
 lastweek  = (datetime.date.today() - datetime.timedelta(days = datetime.date.today().weekday())).strftime('%Y%m%d')
 
@@ -20,6 +20,8 @@ def update_time():
 
     if now != today:
         today = now
+        yesterday = (datetime.date.today() - datetime.timedelta(days = 1)).strftime('%Y%m%d')
+        lastweek  = (datetime.date.today() - datetime.timedelta(days = datetime.date.today().weekday())).strftime('%Y%m%d')
         return True
     else:
         time_left = (RESET_HOUR - time.gmtime().tm_hour) % 24


### PR DESCRIPTION
Al declarar las variables en el scope global, su valor permanéce estático una vez iniciado el servidor, por lo que tanto `yesterday` como `lastweek` no se actualizan y siempre apuntan al mismo punto en el tiempo. Eso significa que al principio el weekly ranking será de 1 semana, pero a medida que avance el tiempo, el weekly ranking irá contando los tacos hasta la semana antes en que se reinició el bot (espero haberme explicado bien 😅 )

Vamos, que la solución para esto es que al igual que actualizamos el valor de `today` cada día en caso de haber cambiado, actualizemos tambien los valores de `yesterday` y de `lastweek`. Con esto, el ranking semanal será de los 7 días anteriores, si queremos que sea de lunes a domingo tendríamos que hacer algunos cambios.